### PR TITLE
Add space in printout

### DIFF
--- a/moxerver/client.c
+++ b/moxerver/client.c
@@ -133,7 +133,7 @@ int client_ask_username(client_t *client)
 	
 	/* show username request to the client */
 	snprintf(msg, BUFFER_LEN,
-			 "\nPlease provide a username to identify yourself to"
+			 "\nPlease provide a username to identify yourself to "
 			 "other users (max %d characters):\n", USERNAME_LEN);
 	client_write(client, msg, strlen(msg));
 	


### PR DESCRIPTION
There is a space missing betweet two words in the "Please provide your username" string to separate "to" and "other". This patch adds a space in the right place.